### PR TITLE
feat: add GitHub Actions workflow for deploying on release creation

### DIFF
--- a/.github/workflows/render_deloy.yml
+++ b/.github/workflows/render_deloy.yml
@@ -1,0 +1,16 @@
+name: My Deploy
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to production
+        uses: johnbeynon/render-deploy-action@v0.0.8
+        with:
+          service-id: ${{ secrets.MY_RENDER_SERVICE_ID }}
+          api-key: ${{ secrets.MY_RENDER_API_KEY }}
+          wait-for-success: true


### PR DESCRIPTION
- Added a new file, `.github/workflows/render_deploy.yml`
- Added a GitHub Actions workflow for deploying on release creation
- Configured the workflow to run on release creation events
- Defined a job named "build" that runs on Ubuntu latest
- Added a step to deploy to production using the `johnbeynon/render-deploy-action` action
- Configured the action with the necessary parameters for deployment