### PR TITLE
build: add Heroku deployment workflow

### DIFF
--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -1,0 +1,16 @@
+name: Heroku Deploy
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: akhileshns/heroku-deploy@v3.12.14 # This is the action
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}} #Must be unique in Heroku
+          heroku_email: ${{secrets.HEROKU_EMAIL}} 


### PR DESCRIPTION
- Add a new file `.github/workflows/heroku_deploy.yml`
- Set up a workflow for deploying to Heroku
- Trigger the workflow on release events
- Use the latest version of Ubuntu as the runner
- Add the step to checkout the repository
- Use the akhileshns/heroku-deploy action for deploying to Heroku
- Pass the Heroku API key, app name, and email as secrets