### PR TITLE
chore: update line-bot-sdk-go version and refactor main.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.1
 
 require (
 	github.com/google/generative-ai-go v0.5.0
-	github.com/line/line-bot-sdk-go/v7 v7.21.0
+	github.com/line/line-bot-sdk-go/v8 v8.2.0
 	google.golang.org/api v0.154.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.2 h1:Vie5ybvEvT75RniqhfF
 github.com/googleapis/enterprise-certificate-proxy v0.3.2/go.mod h1:VLSiSSBs/ksPL8kq3OBOQ6WRI2QnaFynd1DCjZ62+V0=
 github.com/googleapis/gax-go/v2 v2.12.0 h1:A+gCJKdRfqXkr+BIRGtZLibNXf0m1f9E4HG56etFpas=
 github.com/googleapis/gax-go/v2 v2.12.0/go.mod h1:y+aIqrI5eb1YGMVJfuV3185Ts/D7qKpsEkdD5+I6QGU=
-github.com/line/line-bot-sdk-go/v7 v7.21.0 h1:eeYMuAwaDV5DZNTRqDipNhzjT51HwEcM1PRPG+cqh4Y=
-github.com/line/line-bot-sdk-go/v7 v7.21.0/go.mod h1:idpoxOZgtSd8JyhctMMpwg5LNgRAIL/QIxa5S0DXcMg=
+github.com/line/line-bot-sdk-go/v8 v8.2.0 h1:IFqwd3pKbA+o3pwV3nzamtWHt7n+ijSH3t/D8Q/vVQ0=
+github.com/line/line-bot-sdk-go/v8 v8.2.0/go.mod h1:n9Ly8OHM6xCeQktLzRpQHe/yBda95kFgmQUefUQeFCs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
- Upgrade `github.com/line/line-bot-sdk-go` from version 7.21.0 to version 8.2.0 in `go.mod`
- Update imports in `main.go` to use the new version of `line-bot-sdk-go`
- Change the type of `bot` from `*linebot.Client` to `*messaging_api.MessagingApiAPI` in `main.go`
- Add a new variable `blob` of type `*messaging_api.MessagingApiBlobAPI` in `main.go`
- Assign the value of `os.Getenv("ChannelAccessToken")` to `channelToken` in `main.go`
- Update the `bot` initialization in `callbackHandler` function in `main.go` to use the new version of `line-bot-sdk-go`
- Update the `blob` initialization in `callbackHandler` function in `main.go` to use the new version of `line-bot-sdk-go`
- Update the implementation of `replyText` function in `main.go` to use the new version of `line-bot-sdk-go`
- Update the `for` loop in `callbackHandler` function in `main.go` to use the new version of `line-bot-sdk-go`
- Update the `switch` statement in `callbackHandler` function in `main.go` to use the new version of `line-bot-sdk-go`
- Update the implementation of handling sticker messages in `callbackHandler` function in `main.go` to use